### PR TITLE
The dependancy javax-validation is always missing in each child project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,12 @@ Code: https://github.com/springinpractice
 				<version>${jta.version}</version>
 				<scope>runtime</scope>
 			</dependency>
-			<dependency>
-				<groupId>javax.validation</groupId>
-				<artifactId>validation-api</artifactId>
-				<version>${validation.version}</version>
-			</dependency>
+<!-- 			dependancy moved in <dependancies></dependancies> -->
+<!-- 			<dependency> -->
+<!-- 				<groupId>javax.validation</groupId> -->
+<!-- 				<artifactId>validation-api</artifactId> -->
+<!-- 				<version>${validation.version}</version> -->
+<!-- 			</dependency> -->
 			
 			<!-- Apache dependencies -->
 			<dependency>
@@ -606,6 +607,11 @@ Code: https://github.com/springinpractice
 	<dependencies>
 		
 		<!-- JavaEE dependencies -->
+		<dependency>
+				<groupId>javax.validation</groupId>
+				<artifactId>validation-api</artifactId>
+				<version>${validation.version}</version>
+			</dependency>
 		<dependency>
 			<groupId>javax.inject</groupId>
 			<artifactId>com.springsource.javax.inject</artifactId>


### PR DESCRIPTION
(sip01, sip02, ...). It's defined in dependancy management section on
parrnt POM. Thus, maven requires its redefinition in child project above
sip-top. It's a faster way to include this dependancy in <dependencies>
items.